### PR TITLE
Fix error when installing extension with VS2013 and VS2015 CTP installed side by side

### DIFF
--- a/src/ColinsALMCheckinPoliciesInstaller/source.extension.vsixmanifest
+++ b/src/ColinsALMCheckinPoliciesInstaller/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
   <Metadata>
-    <Identity Id="ColinsALMCheckinPolicies..960B39E0-367E-45A8-A300-AEDE505824AD" Version="1.3" Language="en-US" Publisher="Colin Dembovsky" />
+    <Identity Id="ColinsALMCheckinPolicies..960B39E0-367E-45A8-A300-AEDE505824AD" Version="1.3.1" Language="en-US" Publisher="Colin Dembovsky" />
     <DisplayName>Colin's ALM Checkin Policies for VS 2013 and VSO</DisplayName>
     <Description xml:space="preserve">Colin's ALM Corner Custom Checkin Policies, including a Code Review Checkin Policy</Description>
     <MoreInfo>http://colinsalmcorner.com</MoreInfo>
@@ -12,7 +12,6 @@
     <InstallationTarget Id="Microsoft.VisualStudio.IntegratedShell" Version="12.0" />
   </Installation>
   <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="4.5" />
   </Dependencies>
   <Assets>
     <Asset Type="Microsoft.VisualStudio.Assembly" d:Source="Project" d:ProjectName="ColinsALMCheckinPolicies" Path="|ColinsALMCheckinPolicies|" AssemblyName="|ColinsALMCheckinPolicies;AssemblyName|" />


### PR DESCRIPTION
InstallationTarget of version 12.0 (VS2013) implies .NET 4.5 availability

Also upped version to 1.3.1

Fixes #1 
