### PR TITLE
Added Installation Instructions to both policies

### DIFF
--- a/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicy.cs
+++ b/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicy.cs
@@ -206,6 +206,14 @@ namespace ColinsALMCheckinPolicies
 			}
 
 			return responses;
-		}
-	}
+        }
+
+        public override string InstallationInstructions
+        {
+            get
+            {
+                return Constants.InstallationInstructions;
+            }
+        }
+    }
 }

--- a/src/ColinsALMCheckinPolicies/ColinsALMCheckinPolicies.csproj
+++ b/src/ColinsALMCheckinPolicies/ColinsALMCheckinPolicies.csproj
@@ -59,6 +59,7 @@
       <DependentUpon>CodeReviewPolicyForm.cs</DependentUpon>
     </Compile>
     <Compile Include="CodeReview\CodeReviewPolicySerializationBinding.cs" />
+    <Compile Include="Constants.cs" />
     <Compile Include="OneWorkItem\OneWorkItemPolicy.cs" />
     <Compile Include="OneWorkItem\OneWorkItemPolicyConfig.cs" />
     <Compile Include="OneWorkItem\OneWorkItemPolicyForm.cs">

--- a/src/ColinsALMCheckinPolicies/Constants.cs
+++ b/src/ColinsALMCheckinPolicies/Constants.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ColinsALMCheckinPolicies
+{
+    public class Constants
+    {
+        public const string InstallationInstructions = "Install the extension 'Colin's ALM Checkin Policies VS 2015 and VSO' from 'https://visualstudiogallery.msdn.microsoft.com/045730ee-63c0-498e-b972-42b05a2d0857' to get the missing policies.";
+    }
+}

--- a/src/ColinsALMCheckinPolicies/OneWorkItem/OneWorkItemPolicy.cs
+++ b/src/ColinsALMCheckinPolicies/OneWorkItem/OneWorkItemPolicy.cs
@@ -142,5 +142,13 @@ namespace ColinsALMCheckinPolicies
 			
 			return failures.ToArray();
 		}
-	}
+
+        public override string InstallationInstructions
+        {
+            get
+            {
+                return Constants.InstallationInstructions;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Added Installation Instructions so that if someone doesn't have the policies installed they know where to get them from by reading the message thrown when you are missing a check in policy.
