### PR TITLE
Adding PassLevel.None to CodeReviewPolicyConfig and Tests

### DIFF
--- a/src/ColinsALMCheckinPolicies.UnitTests/CodeReviewPolicyTests.cs
+++ b/src/ColinsALMCheckinPolicies.UnitTests/CodeReviewPolicyTests.cs
@@ -497,5 +497,54 @@ namespace ColinsALMCheckinPolicies.UnitTests
 				Assert.IsTrue(failures.Length == 0);
 			}
 		}
-	}
+
+        [TestMethod]
+        [TestCategory("CodeReveiw")]
+        public void TestPolicyFails_When_MinPassLeveIsNone_And_NoRequests()
+        {
+            var policy = new CodeReviewPolicy()
+            {
+                Config = new CodeReviewPolicyConfig()
+                {
+                    RequireReviewToBeClosed = false,
+                    FailIfAnyResponseIsNeedsWork = false,
+                    MinPassLevel = PassLevel.None
+                }
+            };
+
+            using (var context = ShimsContext.Create())
+            {
+                var checkin = FakeUtils.CreatePendingCheckin(new List<ShimWorkItem>());
+
+                policy.Initialize(checkin);
+                var failures = policy.Evaluate();
+                Assert.IsTrue(failures.Length > 0);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("CodeReveiw")]
+        public void TestPolicyPassess_When_MinPassLeveIsNone_And_RequestHasNoResponses()
+        {
+            var policy = new CodeReviewPolicy()
+            {
+                Config = new CodeReviewPolicyConfig()
+                {
+                    RequireReviewToBeClosed = false,
+                    FailIfAnyResponseIsNeedsWork = false,
+                    MinPassLevel = PassLevel.None
+                }
+            };
+
+            using (var context = ShimsContext.Create())
+            {
+                var reviewWorkItem = FakeUtils.CreateCodeReviewRequest(1, "Requested", "", new List<WorkItem>());
+                var checkin = FakeUtils.CreatePendingCheckin(reviewWorkItem);
+
+                policy.Initialize(checkin);
+                var failures = policy.Evaluate();
+                Assert.IsTrue(failures.Length == 0);
+            }
+        }
+    }
 }

--- a/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicy.cs
+++ b/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicy.cs
@@ -174,7 +174,11 @@ namespace ColinsALMCheckinPolicies
 
 			var positiveResponses = responses.Where(r => r.Fields[ClosedStatus].Value.ToString() != "Needs Work" && r.Fields[ClosedStatus].Value.ToString() != "Declined");
 
-			if (Config.MinPassLevel == PassLevel.WithComments)
+            if (Config.MinPassLevel == PassLevel.None)
+            {
+                return true;
+            }
+			else if (Config.MinPassLevel == PassLevel.WithComments)
 			{
 				return positiveResponses.Count() > 0;
 			}

--- a/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyConfig.cs
+++ b/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyConfig.cs
@@ -9,7 +9,8 @@ namespace ColinsALMCheckinPolicies
 	public enum PassLevel
 	{
 		WithComments,
-		LooksGood
+		LooksGood,
+        None
 	}
 
 	[Serializable]

--- a/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyForm.Designer.cs
+++ b/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyForm.Designer.cs
@@ -71,7 +71,8 @@
 			this.cmbPassLevel.FormattingEnabled = true;
 			this.cmbPassLevel.Items.AddRange(new object[] {
             "Looks Good",
-            "With Comments"});
+            "With Comments",
+            "None"});
 			this.cmbPassLevel.Location = new System.Drawing.Point(152, 85);
 			this.cmbPassLevel.Margin = new System.Windows.Forms.Padding(4, 5, 4, 5);
 			this.cmbPassLevel.Name = "cmbPassLevel";

--- a/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyForm.cs
+++ b/src/ColinsALMCheckinPolicies/CodeReview/CodeReviewPolicyForm.cs
@@ -34,6 +34,10 @@ namespace ColinsALMCheckinPolicies
 			{
 				cmbPassLevel.SelectedItem = "Looks Good";
 			}
+            else if (Config.MinPassLevel == PassLevel.None)
+            {
+                cmbPassLevel.SelectedItem = "None";
+            }
 
 			lstPaths.Items.Clear();
 			config.Paths.ForEach(p => lstPaths.Items.Add(p));
@@ -50,6 +54,10 @@ namespace ColinsALMCheckinPolicies
 			{
 				Config.MinPassLevel = PassLevel.WithComments;
 			}
+            else if (cmbPassLevel.SelectedItem.ToString() == "None")
+            {
+                Config.MinPassLevel = PassLevel.None;
+            }
 		}
 
 		void chkRequireClose_CheckedChanged(object sender, EventArgs e)


### PR DESCRIPTION
Hey Colin,

My company wants to use your Check-in Policy to promote code reviews.  However, we don't want to block developers from checking in while waiting for reviews to complete.  We just want to make sure the code review was requested at check in.  If you feel this feature makes sense for your application, I'd love to see it merged in.

Thanks,
Brett
