### PR TITLE
Update manifest for VS2019 support

### DIFF
--- a/src/ColinsALMCheckinPoliciesInstaller/source.extension.vsixmanifest
+++ b/src/ColinsALMCheckinPoliciesInstaller/source.extension.vsixmanifest
@@ -3,14 +3,14 @@
     <Metadata>
         <Identity Id="ColinsALMCheckinPolicies..dfc50aa1-4615-441e-96ca-14bee3946343" Version="3.20" Language="en-US" Publisher="colind" />
         <DisplayName>Colin's ALM Checkin Policies VS 2017</DisplayName>
-        <Description xml:space="preserve">Colin's ALM Corner Custom Checkin Policies, including a Code Review Checkin Policy for VS 2017</Description>
+        <Description xml:space="preserve">Colin's ALM Corner Custom Checkin Policies, including a Code Review Checkin Policy for VS 2019</Description>
         <MoreInfo>http://colinsalmcorner.com</MoreInfo>
         <License>license.txt</License>
         <Tags>Code Review; Checkin Policies</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.Community" />
-        <InstallationTarget Version="[15.0,16.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.Community" />
+        <InstallationTarget Version="[15.0,17.0)" Id="Microsoft.VisualStudio.IntegratedShell" />
     </Installation>
     <Dependencies>
     </Dependencies>
@@ -19,6 +19,6 @@
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="ColinsALMCheckinPolicies.pkgdef" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0,17.0)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
I have updated the VSIX manifest so that the extension can be installed into VS 2019, as per Issue #27.